### PR TITLE
BOT展示更新时间统一为UTC

### DIFF
--- a/tgbot.go
+++ b/tgbot.go
@@ -91,7 +91,7 @@ CPU核心数： %d
 上行流量： ↑%s
 流量对等性： %s
 
-更新于：%s`, len(mm), online, cpu, fmt.Sprintf("%.2f%%", float64(memused)/float64(mem)*100), formatSize(memused), formatSize(mem), fmt.Sprintf("%.2f%%", float64(swapused)/float64(swap)*100), formatSize(swapused), formatSize(swap), formatSize(downspeed), formatSize(upspeed), formatSize(downflow), formatSize(upflow), duideng, time.Now().Format("2006-01-02 15:04:05"))
+更新于：%s UTC`, len(mm), online, cpu, fmt.Sprintf("%.2f%%", float64(memused)/float64(mem)*100), formatSize(memused), formatSize(mem), fmt.Sprintf("%.2f%%", float64(swapused)/float64(swap)*100), formatSize(swapused), formatSize(swap), formatSize(downspeed), formatSize(upspeed), formatSize(downflow), formatSize(upflow), duideng, time.Now().UTC().Format("2006-01-02 15:04:05"))
 					bot.Send(tgbotapi.NewMessage(update.Message.Chat.ID, msg))
 				}
 			} else if update.Message.Command() == "id" {


### PR DESCRIPTION
之前的代码中，Bot展示的更新时间为主控后端的本地时间，且没有时区标注，这里统一为UTC协调世界时展示，并标注UTC