### PR TITLE
加入单台服务器信息展示功能，修复id获取

### DIFF
--- a/tgbot.go
+++ b/tgbot.go
@@ -91,15 +91,140 @@ CPU核心数： %d
 上行流量： ↑%s
 流量对等性： %s
 
-更新于：%s UTC`, len(mm), online, cpu, fmt.Sprintf("%.2f%%", float64(memused)/float64(mem)*100), formatSize(memused), formatSize(mem), fmt.Sprintf("%.2f%%", float64(swapused)/float64(swap)*100), formatSize(swapused), formatSize(swap), formatSize(downspeed), formatSize(upspeed), formatSize(downflow), formatSize(upflow), duideng, time.Now().UTC().Format("2006-01-02 15:04:05"))
+更新于：%s UTC`,
+						len(mm), online, cpu,
+						fmt.Sprintf("%.2f%%", float64(memused)/float64(mem)*100),
+						formatSize(memused), formatSize(mem),
+						fmt.Sprintf("%.2f%%", float64(swapused)/float64(swap)*100),
+						formatSize(swapused), formatSize(swap),
+						formatSize(downspeed), formatSize(upspeed),
+						formatSize(downflow), formatSize(upflow),
+						duideng,
+						time.Now().UTC().Format("2006-01-02 15:04:05"),
+					)
 					bot.Send(tgbotapi.NewMessage(update.Message.Chat.ID, msg))
+				} else if update.Message.Command() == "id" {
+					msg := tgbotapi.NewMessage(update.Message.Chat.ID, fmt.Sprintf("你的ID是: %d", update.Message.From.ID))
+					bot.Send(msg)
+				} else if update.Message.Command() == "server" {
+					var servers []Data
+					db.Model(&Data{}).Find(&servers)
+
+					if len(servers) == 0 {
+						bot.Send(tgbotapi.NewMessage(update.Message.Chat.ID, "没有找到任何服务器信息。"))
+						return
+					}
+
+					var rows [][]tgbotapi.InlineKeyboardButton
+					row := []tgbotapi.InlineKeyboardButton{}
+					for i, server := range servers {
+						callbackData := fmt.Sprintf("/status %s", server.Name)
+						row = append(row, tgbotapi.NewInlineKeyboardButtonData(server.Name, callbackData))
+						if (i+1)%2 == 0 {
+							rows = append(rows, row)
+							row = []tgbotapi.InlineKeyboardButton{}
+						}
+					}
+					if len(row) > 0 {
+						rows = append(rows, row)
+					}
+
+					keyboard := tgbotapi.NewInlineKeyboardMarkup(rows...)
+					msg := tgbotapi.NewMessage(update.Message.Chat.ID, "请选择一个服务器:")
+					msg.ReplyMarkup = keyboard
+					bot.Send(msg)
+				} else if update.Message.Command() == "status" {
+					serverName := update.Message.CommandArguments()
+					if serverName == "" {
+						bot.Send(tgbotapi.NewMessage(update.Message.Chat.ID, "用法: /status <服务器名称>"))
+					} else {
+						sendOrEditServerStatus(bot, update.Message.Chat.ID, 0, serverName)
+					}
 				}
-			} else if update.Message.Command() == "id" {
-				msg := tgbotapi.NewMessage(update.Message.From.ID, "Your ID is "+strconv.FormatInt(update.Message.From.ID, 10))
-				bot.Send(msg)
+			}
+		} else if update.CallbackQuery != nil {
+			callbackData := update.CallbackQuery.Data
+			if len(callbackData) > 8 && callbackData[:8] == "/status " {
+				serverName := callbackData[8:]
+				// 编辑原消息并展示服务器信息
+				sendOrEditServerStatus(bot, update.CallbackQuery.Message.Chat.ID, update.CallbackQuery.Message.MessageID, serverName)
 			}
 		}
 	}
+}
+
+// 新建/编辑消息展示单个服务器信息
+func sendOrEditServerStatus(bot *tgbotapi.BotAPI, chatID int64, messageID int, serverName string) {
+	var data Data
+	if err := db.First(&data, "name = ?", serverName).Error; err != nil {
+		// messageID != 0 说明消息来自点击列表中按钮回调, 只需要编辑原信息; 否则消息来自直接调用 /status 命令, 需要新建信息
+		if messageID != 0 {
+			editMsg := tgbotapi.NewEditMessageText(chatID, messageID, "未找到指定的服务器信息。")
+			bot.Send(editMsg)
+		} else {
+			bot.Send(tgbotapi.NewMessage(chatID, "未找到指定的服务器信息。"))
+		}
+		return
+	}
+
+	var m M
+	if err := json.Unmarshal([]byte(data.Data), &m); err != nil {
+		// messageID != 0 说明消息来自点击列表中按钮回调, 只需要编辑原信息; 否则消息来自直接调用 /status 命令, 需要新建信息
+		if messageID != 0 {
+			editMsg := tgbotapi.NewEditMessageText(chatID, messageID, "解析服务器数据失败。")
+			bot.Send(editMsg)
+		} else {
+			bot.Send(tgbotapi.NewMessage(chatID, "解析服务器数据失败。"))
+		}
+		return
+	}
+
+	msgText := formatServerMessage(serverName, &m)
+	if messageID != 0 {
+		editMsg := tgbotapi.NewEditMessageText(chatID, messageID, msgText)
+		bot.Send(editMsg)
+	} else {
+		bot.Send(tgbotapi.NewMessage(chatID, msgText))
+	}
+}
+
+// 格式化服务器信息
+func formatServerMessage(serverName string, m *M) string {
+	//流量对等性
+	var duideng string
+	if m.State.NetInTransfer > m.State.NetOutTransfer {
+		duideng = fmt.Sprintf("%.2f%%", float64(m.State.NetOutTransfer)/float64(m.State.NetInTransfer)*100)
+	} else {
+		duideng = fmt.Sprintf("%.2f%%", float64(m.State.NetInTransfer)/float64(m.State.NetOutTransfer)*100)
+	}
+	return fmt.Sprintf(`服务器: %s
+CPU核心数: %d
+内存: %s [%s/%s]
+交换分区: %s [%s/%s]
+下行速度: ↓%s/s
+上行速度: ↑%s/s
+下行流量: ↓%s
+上行流量: ↑%s
+流量对等性: %s
+运行时间: %s
+
+更新于: %s UTC`,
+		serverName,
+		parseCPU(m.Host.CPU[0]),
+		fmt.Sprintf("%.2f%%", float64(m.State.MemUsed)/float64(m.Host.MemTotal)*100),
+		formatSize(m.State.MemUsed),
+		formatSize(m.Host.MemTotal),
+		fmt.Sprintf("%.2f%%", float64(m.State.SwapUsed)/float64(m.Host.SwapTotal)*100),
+		formatSize(m.State.SwapUsed),
+		formatSize(m.Host.SwapTotal),
+		formatSize(m.State.NetInSpeed),
+		formatSize(m.State.NetOutSpeed),
+		formatSize(m.State.NetInTransfer),
+		formatSize(m.State.NetOutTransfer),
+		duideng,
+		time.Duration(m.State.Uptime)*time.Second,
+		time.Now().UTC().Format("2006-01-02 15:04:05"),
+	)
 }
 
 // 解析CPU数量


### PR DESCRIPTION
更新点：

1. 加入了两个新的tgbot命令
  - `/status`: 传入服务器名称，返回某台特定的服务器信息
    效果如下图：
    ![image](https://github.com/user-attachments/assets/22a18c99-17cf-4deb-8dce-99fe2c113e2e)
  - `/server`: 展示一个列表，列举出已有服务器，点击后展示被点击服务器信息
    点击前效果如下图：
    ![image](https://github.com/user-attachments/assets/af42ae29-2a57-433e-892c-1300f49165f7)
    点击后效果如下图：
    ![image](https://github.com/user-attachments/assets/e380f4c2-dd01-41f8-9a02-c506aaa34f7e)
2. 修复了发送`/id`命令不回复的bug